### PR TITLE
Allow colon delimiter between role and account name

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ A configuration wizard will prompt you to enter the necessary configuration para
 - write_aws_creds - True or False - If True, the AWS credentials will be written to `~/.aws/credentials` otherwise it will be written to stdout.
 - cred_profile - If writing to the AWS cred file, this sets the name of the AWS credential profile.
   - The reserved word `role` will use the name component of the role arn as the profile name. i.e. arn:aws:iam::123456789012:role/okta-1234-role becomes section [okta-1234-role] in the aws credentials file
-  - The reserved word `acc-role` will use the name component of the role arn prepended with account number (or alias if `resolve_aws_alias` is set to y) to avoid collisions, i.e. arn:aws:iam::123456789012:role/okta-1234-role becomes section [123456789012-okta-1234-role], or if `resolve_aws_alias` [<my alias>-okta-1234-role] in the aws credentials file
+  - The reserved words `acc-role` or `acc:role` will use the name component of the role arn prepended with the indicated delimiter and the account number (or alias if `resolve_aws_alias` is set to y) to avoid collisions, i.e. arn:aws:iam::123456789012:role/okta-1234-role becomes section [123456789012-okta-1234-role], or if `resolve_aws_alias` [<my alias>-okta-1234-role] in the aws credentials file
   - If set to `default` then the temp creds will be stored in the default profile
   - Note: if there are multiple roles, and `default` is selected it will be overwritten multiple times and last role wins. The same happens when `role` is selected and you have many accounts with the same role names. Consider using `acc-role` if this happens.
 - aws_appname - This is optional. The Okta AWS App name, which has the role you want to assume.

--- a/gimme_aws_creds/__init__.py
+++ b/gimme_aws_creds/__init__.py
@@ -1,2 +1,2 @@
 __all__ = ['config', 'okta', 'main', 'ui']
-version = '2.3.4.1'
+version = '2.3.4.2'

--- a/gimme_aws_creds/config.py
+++ b/gimme_aws_creds/config.py
@@ -418,7 +418,7 @@ class Config(object):
         ui.default.message(
             "The AWS credential profile defines which profile is used to store the temp AWS creds.\n"
             "If set to 'role' then a new profile will be created matching the role name assumed by the user.\n"
-            "If set to 'acc-role' then a new profile will be created matching the role name assumed by the user, but prefixed with account number to avoid collisions.\n"
+            "If set to 'acc-role' or 'acc:role' then a new profile will be created matching the role name assumed by the user, but prefixed with account alias or number and the given delimiter to avoid collisions.\n"
             "If set to 'default' then the temp creds will be stored in the default profile\n"
             "If set to any other value, the name of the profile will match that value."
         )
@@ -426,7 +426,7 @@ class Config(object):
         cred_profile = self._get_user_input(
             "AWS Credential Profile", default_entry)
 
-        if cred_profile.lower() in ['default', 'role', 'acc-role']:
+        if cred_profile.lower() in ['default', 'role', 'acc-role', 'acc:role']:
             cred_profile = cred_profile.lower()
 
         return cred_profile

--- a/gimme_aws_creds/main.py
+++ b/gimme_aws_creds/main.py
@@ -750,7 +750,8 @@ class GimmeAWSCreds(object):
             profile_name = 'default'
         elif cred_profile.lower() == 'role':
             profile_name = naming_data['role']
-        elif cred_profile.lower() == 'acc-role':
+        elif cred_profile.lower() in ['acc-role', 'acc:role']:
+            delimiter = cred_profile[3]
             account = naming_data['account']
             role_name = naming_data['role']
             path = naming_data['path']
@@ -760,7 +761,7 @@ class GimmeAWSCreds(object):
                     account = account_alias
             if include_path == 'True':
                 role_name = ''.join([path, role_name])
-            profile_name = '-'.join([account,
+            profile_name = delimiter.join([account,
                                      role_name])
         else:
             profile_name = cred_profile

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -178,6 +178,19 @@ class TestMain(unittest.TestCase):
         include_path = 'False'
         self.assertEqual(creds.get_profile_name(cred_profile, include_path, naming_data, resolve_alias, role), "my-org-master-administrator")
 
+    def test_get_profile_name_acc_colon_role_resolve_alias_do_not_include_paths(self):
+        "Testing the acc:role, with alias resolution, and not including full role path"
+        creds = GimmeAWSCreds()
+        naming_data = {'account': '123456789012', 'role': 'administrator', 'path': '/administrator/'}
+        role = RoleSet(idp='arn:aws:iam::123456789012:saml-provider/my-okta-provider',
+                       role='arn:aws:iam::123456789012:role/administrator/administrator',
+                       friendly_account_name='Account: my-org-master (123456789012)',
+                       friendly_role_name='administrator/administrator')
+        cred_profile = 'acc:role'
+        resolve_alias = 'True'
+        include_path = 'False'
+        self.assertEqual(creds.get_profile_name(cred_profile, include_path, naming_data, resolve_alias, role), "my-org-master:administrator")
+
     def test_get_profile_accrole_name_do_not_resolve_alias_do_not_include_paths(self):
         "Testing the acc-role, without alias resolution, and not including full role path"
         creds = GimmeAWSCreds()


### PR DESCRIPTION
## Description
Allow an alternative to `acc-role` called `acc:role` which separates the account id or alias from the (path and) role name by a colon instead of a hyphen, for compatibility with Terraform written to assume AWS credential profiles named by samlkeygen.

## Related Issue
#1 

## Motivation and Context
See the issue for more context, but we have a large number of users with multiple codebases that were written to assume the previous tool's profile naming scheme. 

## How Has This Been Tested?
Added a test, but `make test` doesn't seem to work, even in upstream HEAD.  Manually tested by running the docker build and selecting acc:role and confirming that the profile name was correct, then running it again with acc-role, role, and arbitrary strings to make sure those still came out as well.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
