### PR TITLE
Manually install futures to avoid setup.py failure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ ENV PACKAGES="gcc musl-dev python3-dev libffi-dev openssl-dev cargo"
 
 RUN apk --update add $PACKAGES \
     && pip install --upgrade pip setuptools-rust \
+    && pip install futures \
     && python setup.py install \
     && apk del --purge $PACKAGES
 

--- a/gimme_aws_creds/__init__.py
+++ b/gimme_aws_creds/__init__.py
@@ -1,2 +1,2 @@
 __all__ = ['config', 'okta', 'main', 'ui']
-version = '2.4.1.1'
+version = '2.4.1.2'


### PR DESCRIPTION
Latest versions are failing to build in Docker with an error about futures being a Python2 module that should not be installed in Python3. This error is not present if futures is installed directly by pip instead of as a dependency by setup.py, so this workaround adds a manual install step to the Dockerfile.