### PR TITLE
Acoppolawb/wbfixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ You can run a specific configuration profile with the `--profile` parameter:
 
 The username and password you are prompted for are the ones you login to Okta with. You can predefine your username by setting the `OKTA_USERNAME` environment variable or using the `-u username` parameter.
 
-If you have not configured an Okta App or Role, you will prompted to select one.
+If you have not configured an Okta App or Role, you will prompted to select one. If you want to filter the resulting list (for those will access to hundreds of roles), you can make use of the `--filter-selection/-f` option like so: `gimme-aws-creds -f prod` which would return only the roles where the account name starts with prod. Note: use of the `-f` option requires `resolve_aws_alias` to be set to `True` to work properly.
 
 If all goes well you will get your temporary AWS access, secret key and token, these will either be written to stdout or `~/.aws/credentials`.
 

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ You can run a specific configuration profile with the `--profile` parameter:
 
 The username and password you are prompted for are the ones you login to Okta with. You can predefine your username by setting the `OKTA_USERNAME` environment variable or using the `-u username` parameter.
 
-If you have not configured an Okta App or Role, you will prompted to select one. If you want to filter the resulting list (for those will access to hundreds of roles), you can make use of the `--filter-selection/-f` option like so: `gimme-aws-creds -f prod` which would return only the roles where the account name starts with prod. Note: use of the `-f` option requires `resolve_aws_alias` to be set to `True` to work properly.
+If you have not configured an Okta App or Role, you will prompted to select one. If you want to filter the resulting list (for those with access to hundreds of roles), you can make use of the `--filter-selection/-f` option like so: `gimme-aws-creds -f prod` which would return only the roles where the account name starts with prod. Note: use of the `-f` option requires `resolve_aws_alias` to be set to `True` to work as intended.
 
 If all goes well you will get your temporary AWS access, secret key and token, these will either be written to stdout or `~/.aws/credentials`.
 

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ You can run a specific configuration profile with the `--profile` parameter:
 
 The username and password you are prompted for are the ones you login to Okta with. You can predefine your username by setting the `OKTA_USERNAME` environment variable or using the `-u username` parameter.
 
-If you have not configured an Okta App or Role, you will prompted to select one. If you want to filter the resulting list (for those with access to hundreds of roles), you can make use of the `--filter-selection/-f` option like so: `gimme-aws-creds -f prod` which would return only the roles where the account name starts with prod. Note: use of the `-f` option requires `resolve_aws_alias` to be set to `True` to work as intended.
+If you have not configured an Okta App or Role, you will prompted to select one. If you want to filter the resulting list (for those with access to hundreds of roles), you can make use of the `--filter-selection/-f` option like so: `gimme-aws-creds -f prod` which would return only the roles where the account name contains the string `prod`. Note: use of the `-f` option requires `resolve_aws_alias` to be set to `True` to work as intended.
 
 If all goes well you will get your temporary AWS access, secret key and token, these will either be written to stdout or `~/.aws/credentials`.
 

--- a/README.md
+++ b/README.md
@@ -102,8 +102,9 @@ A configuration wizard will prompt you to enter the necessary configuration para
 - cred_profile - If writing to the AWS cred file, this sets the name of the AWS credential profile.
   - The reserved word `role` will use the name component of the role arn as the profile name. i.e. arn:aws:iam::123456789012:role/okta-1234-role becomes section [okta-1234-role] in the aws credentials file
   - The reserved words `acc-role` or `acc:role` will use the name component of the role arn prepended with the indicated delimiter and the account number (or alias if `resolve_aws_alias` is set to y) to avoid collisions, i.e. arn:aws:iam::123456789012:role/okta-1234-role becomes section [123456789012-okta-1234-role], or if `resolve_aws_alias` [<my alias>-okta-1234-role] in the aws credentials file
+  - The reserved word `acc` will use the account number (or alias if `resolve_aws_alias` is set to y).
   - If set to `default` then the temp creds will be stored in the default profile
-  - Note: if there are multiple roles, and `default` is selected it will be overwritten multiple times and last role wins. The same happens when `role` is selected and you have many accounts with the same role names. Consider using `acc-role` if this happens.
+  - Note: if there are multiple roles, and `default` is selected it will be overwritten multiple times and last role wins. The same happens when `role` or `acc` is selected and you have many accounts with the same role names. Consider using `acc-role` if this happens.
 - aws_appname - This is optional. The Okta AWS App name, which has the role you want to assume.
 - aws_rolename - This is optional. The ARN of the role you want temporary AWS credentials for.  The reserved word 'all' can be used to get and store credentials for every role the user is permissioned for.
 - aws_default_duration = This is optional. Lifetime for temporary credentials, in seconds. Defaults to 1 hour (3600)

--- a/gimme_aws_creds/__init__.py
+++ b/gimme_aws_creds/__init__.py
@@ -1,2 +1,2 @@
 __all__ = ['config', 'okta', 'main', 'ui']
-version = '2.4.3.1'
+version = '2.4.3.2'

--- a/gimme_aws_creds/config.py
+++ b/gimme_aws_creds/config.py
@@ -55,6 +55,7 @@ class Config(object):
         self.action_output_format = False
         self.output_format = 'export'
         self.roles = []
+        self.filter_selection = ""
 
         if self.ui.environ.get("OKTA_USERNAME") is not None:
             self.username = self.ui.environ.get("OKTA_USERNAME")
@@ -105,6 +106,15 @@ class Config(object):
                  'can be regex in format /<pattern>/. '
                  'for example: arn:aws:iam::123456789012:role/Admin,/:210987654321:/ '
                  'would match both account 123456789012 by ARN and 210987654321 by regexp'
+        )
+        parser.add_argument(
+            '--filter-selection', '-f',
+            help='If set, the input will be used to filter the list of roles presented to the user. '
+                 'The filter acts on the so called \'friendly_account_name\' associated with each role. '
+                 'The friendly account name contains the account name and number. '
+                 'For example: \'nonprod\' would match any roles where the text \'nonprod\' is found. '
+                 'If only one match is found, it will be auto selected and credentials generated. '
+                 'If no results are found, the program exits.'
         )
         parser.add_argument(
             '--resolve', '-r',
@@ -173,6 +183,8 @@ class Config(object):
             self.output_format = args.output_format
         if args.roles is not None:
             self.roles = [role.strip() for role in args.roles.split(',') if role.strip()]
+        if args.filter_selection is not None:
+            self.filter_selection = args.filter_selection.strip()
         self.conf_profile = args.profile or 'DEFAULT'
 
     def _handle_config(self, config, profile_config, include_inherits = True):

--- a/gimme_aws_creds/config.py
+++ b/gimme_aws_creds/config.py
@@ -444,6 +444,7 @@ class Config(object):
             "The AWS credential profile defines which profile is used to store the temp AWS creds.\n"
             "If set to 'role' then a new profile will be created matching the role name assumed by the user.\n"
             "If set to 'acc-role' or 'acc:role' then a new profile will be created matching the role name assumed by the user, but prefixed with account alias or number and the given delimiter to avoid collisions.\n"
+            "If set to 'acc' then a new profile will be created matching the account number (or alias if resolve is set to True)\n"
             "If set to 'default' then the temp creds will be stored in the default profile\n"
             "If set to any other value, the name of the profile will match that value."
         )
@@ -451,7 +452,7 @@ class Config(object):
         cred_profile = self._get_user_input(
             "AWS Credential Profile", default_entry)
 
-        if cred_profile.lower() in ['default', 'role', 'acc-role', 'acc:role']:
+        if cred_profile.lower() in ['default', 'role', 'acc', 'acc-role', 'acc:role']:
             cred_profile = cred_profile.lower()
 
         return cred_profile

--- a/gimme_aws_creds/main.py
+++ b/gimme_aws_creds/main.py
@@ -372,7 +372,7 @@ class GimmeAWSCreds(object):
 
         return selection
 
-    def _get_selected_roles(self, requested_roles, aws_roles):
+    def _get_selected_roles(self, requested_roles, aws_roles, filter_selection=None):
         """ select the role from the config file if it exists in the
         results from Okta.  If not, present the user with a menu. """
         # 'all' is a special case - skip processing
@@ -399,6 +399,10 @@ class GimmeAWSCreds(object):
                 return ret
             self.ui.error("ERROR: AWS roles [{}] not found!".format(', '.join(requested_roles)))
 
+        if filter_selection:
+            filtered_roles = [role for role in aws_roles if filter_selection in role.friendly_account_name]
+            return self._choose_roles(filtered_roles)
+        
         # Present the user with a list of roles to choose from
         return self._choose_roles(aws_roles)
 
@@ -669,7 +673,7 @@ class GimmeAWSCreds(object):
     def aws_selected_roles(self):
         if 'aws_selected_roles' in self._cache:
             return self._cache['aws_selected_roles']
-        selected_roles = self._get_selected_roles(self.requested_roles, self.aws_roles)
+        selected_roles = self._get_selected_roles(self.requested_roles, self.aws_roles, self.config.filter_selection)
         self._cache['aws_selected_roles'] = ret = [
             role
             for role in self.aws_roles

--- a/gimme_aws_creds/main.py
+++ b/gimme_aws_creds/main.py
@@ -372,12 +372,13 @@ class GimmeAWSCreds(object):
 
         return selection
 
-    def _get_selected_roles(self, requested_roles, aws_roles, filter_selection=None):
+    def _get_selected_roles(self, requested_roles, aws_roles, filter_selection=""):
         """ select the role from the config file if it exists in the
         results from Okta.  If not, present the user with a menu. """
+        filtered_roles = [role for role in aws_roles if filter_selection in role.friendly_account_name]
         # 'all' is a special case - skip processing
         if requested_roles == 'all':
-            return set(role.role for role in aws_roles)
+            return set(role.role for role in filtered_roles)
         # check to see if a role is in the config and look for it in the results from Okta
         if requested_roles:
             ret = set()
@@ -400,7 +401,6 @@ class GimmeAWSCreds(object):
             self.ui.error("ERROR: AWS roles [{}] not found!".format(', '.join(requested_roles)))
 
         if filter_selection:
-            filtered_roles = [role for role in aws_roles if filter_selection in role.friendly_account_name]
             return self._choose_roles(filtered_roles)
         
         # Present the user with a list of roles to choose from

--- a/gimme_aws_creds/main.py
+++ b/gimme_aws_creds/main.py
@@ -771,6 +771,13 @@ class GimmeAWSCreds(object):
             profile_name = 'default'
         elif cred_profile.lower() == 'role':
             profile_name = naming_data['role']
+        elif cred_profile.lower() == 'acc':
+            account = naming_data['account']
+            if resolve_alias == 'True':
+                account_alias = self._get_alias_from_friendly_name(role.friendly_account_name)
+                if account_alias:
+                    account = account_alias
+            profile_name = account
         elif cred_profile.lower() in ['acc-role', 'acc:role']:
             delimiter = cred_profile[3]
             account = naming_data['account']

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -31,6 +31,7 @@ class TestConfig(unittest.TestCase):
             remember_device=False,
             output_format=None,
             roles=None,
+            filter_selection = None,
             action_register_device=False,
             action_configure=False,
             action_list_profiles=False,

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -231,6 +231,33 @@ class TestMain(unittest.TestCase):
         self.assertEqual(creds.get_profile_name(cred_profile, include_path, naming_data, resolve_alias, role),
                          'administrator')
 
+    # From https://github.com/Nike-Inc/gimme-aws-creds/pull/294/files
+    def test_get_profile_name_acc_resolve_alias(self):
+        "Testing the acc, with alias resolution, and not including full role path"
+        creds = GimmeAWSCreds()
+        naming_data = {'account': '123456789012', 'role': 'administrator', 'path': '/administrator/'}
+        role = RoleSet(idp='arn:aws:iam::123456789012:saml-provider/my-okta-provider',
+                       role='arn:aws:iam::123456789012:role/administrator/administrator',
+                       friendly_account_name='Account: my-org-master (123456789012)',
+                       friendly_role_name='administrator/administrator')
+        cred_profile = 'acc'
+        resolve_alias = 'False'
+        include_path = 'False'
+        self.assertEqual(creds.get_profile_name(cred_profile, include_path, naming_data, resolve_alias, role), "123456789012")
+
+    def test_get_profile_name_acc_do_not_resolve_alias(self):
+        "Testing the acc, with alias resolution, and not including full role path"
+        creds = GimmeAWSCreds()
+        naming_data = {'account': '123456789012', 'role': 'administrator', 'path': '/administrator/'}
+        role = RoleSet(idp='arn:aws:iam::123456789012:saml-provider/my-okta-provider',
+                       role='arn:aws:iam::123456789012:role/administrator/administrator',
+                       friendly_account_name='Account: my-org-master (123456789012)',
+                       friendly_role_name='administrator/administrator')
+        cred_profile = 'acc'
+        resolve_alias = 'True'
+        include_path = 'False'
+        self.assertEqual(creds.get_profile_name(cred_profile, include_path, naming_data, resolve_alias, role), "my-org-master")
+    
     def test_get_profile_name_default(self):
         "Testing the default"
         creds = GimmeAWSCreds()


### PR DESCRIPTION
This PR combines two existing PRs from the Nike repo:
* https://github.com/Nike-Inc/gimme-aws-creds/pull/294
* https://github.com/Nike-Inc/gimme-aws-creds/pull/316

Reproduced below.

# Reproduction of PR 294
Support AWS account IDs or aliases as profile names

## Description

In many orgs (like mine) we use a single role in multiple accounts.

## Related Issue

Resolves https://github.com/Nike-Inc/gimme-aws-creds/issues/293

## Motivation and Context

We have a lot of AWS accounts, and their names are long enough - using the roles makes it hard to use the cli with the resulting credentials.

## How Has This Been Tested?

Added UT

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

# Reproduction of PR 316

Feat filter selection: adds --filter-selection/-f option to filter generated role selection screen

## Description

This option will filter out the list of roles generated when calling `gimme-aws-creds` to show only those that contain a match on the passed in string.

Example: `gimme-aws-creds` might return:
```
Account: myaccount-poc (#)
  [ 1 ]: Admin
Account: myaccount-dev1 (#)
  [ 2 ]: Admin
Account: myaccount-dev2 (#)
  [ 3 ]: Admin
Account: myaccount-prod (#)
  [ 4 ]: Admin
Selections (comma separated): 
```

And `gimme-aws-creds -f dev` would return:
```
Account: myaccount-dev1 (#)
  [ 1 ]: Admin
Account: myaccount-dev2 (#)
  [ 2 ]: Admin
Selections (comma separated): 
```
If only one match is found, it is auto selected (already the default behavior - not part of this feature).

If the user has their `~/.okta_aws_login_config` file set so that `aws_rolename = all` then passing in the `-f` option causes creds to be generated against the filtered list instead of every role available to the user. I.e: `gimme-aws-creds -f poc` would grab creds only for matching roles, whereas `aws-gimme-creds` would still grab creds for all roles.


## Related Issue
None

## Motivation and Context
This change is helpful for users with access to many roles. For instance, my team at WarnerBros has access to hundreds of roles across hundreds of AWS accounts, and selecting the one we need at a given time from a long list is tedious. This option lets us call the specific account we need access to, or a part of it (the list of poc accounts, or dev accounts, or prod accounts), and select from a much smaller list.

## How Has This Been Tested?
This change was tested manually by running:
1. `gimme-aws-creds` by itself and verifying the resulting list.
2. `gimme-aws-creds -f poc` and verifying the resulting list, selecting one and verifying the resulting creds worked with an `aws --profile aws-aio-poc sts get-caller-identity` call.
3. `gimme-aws-creds -f aws-aio-poc` and verifying the generated creds worked with an `aws --profile aws-aio-poc sts get-caller-identity` call.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
