### PR TITLE
Fix missing dependency on libgcc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@ WORKDIR /opt/gimme-aws-creds
 
 COPY . .
 
+RUN apk --update add libgcc
+
 ENV PACKAGES="gcc musl-dev python3-dev libffi-dev openssl-dev cargo"
 
 RUN apk --update add $PACKAGES \

--- a/gimme_aws_creds/__init__.py
+++ b/gimme_aws_creds/__init__.py
@@ -1,2 +1,2 @@
 __all__ = ['config', 'okta', 'main', 'ui']
-version = '2.4.3.1'
+version = '2.4.3.2'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add `libgcc` package to build plan

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/Nike-Inc/gimme-aws-creds/issues/321

## Motivation and Context
Docker image fails to run:

```
Traceback (most recent call last):
  File "/usr/local/bin/gimme-aws-creds", line 4, in <module>
    __import__('pkg_resources').run_script('gimme-aws-creds==2.4.3.1', 'gimme-aws-creds')
  File "/usr/local/lib/python3.8/site-packages/pkg_resources/__init__.py", line 651, in run_script
    self.require(requires)[0].run_script(script_name, ns)
  File "/usr/local/lib/python3.8/site-packages/pkg_resources/__init__.py", line 1455, in run_script
    exec(script_code, namespace, namespace)
  File "/usr/local/lib/python3.8/site-packages/gimme_aws_creds-2.4.3.1-py3.8.egg/EGG-INFO/scripts/gimme-aws-creds", line 13, in <module>
  File "<frozen zipimport>", line 259, in load_module
  File "/usr/local/lib/python3.8/site-packages/gimme_aws_creds-2.4.3.1-py3.8.egg/gimme_aws_creds/main.py", line 32, in <module>
  File "<frozen zipimport>", line 259, in load_module
  File "/usr/local/lib/python3.8/site-packages/gimme_aws_creds-2.4.3.1-py3.8.egg/gimme_aws_creds/okta.py", line 33, in <module>
  File "<frozen zipimport>", line 259, in load_module
  File "/usr/local/lib/python3.8/site-packages/gimme_aws_creds-2.4.3.1-py3.8.egg/gimme_aws_creds/u2f.py", line 19, in <module>
  File "/usr/local/lib/python3.8/site-packages/fido2-0.9.3-py3.8.egg/fido2/ctap1.py", line 32, in <module>
    from .cose import ES256
  File "/usr/local/lib/python3.8/site-packages/fido2-0.9.3-py3.8.egg/fido2/cose.py", line 32, in <module>
    from cryptography.hazmat.primitives import hashes, serialization
  File "/usr/local/lib/python3.8/site-packages/cryptography-36.0.0-py3.8-linux-x86_64.egg/cryptography/hazmat/primitives/serialization/__init__.py", line 15, in <module>
    from cryptography.hazmat.primitives.serialization.base import (
  File "/usr/local/lib/python3.8/site-packages/cryptography-36.0.0-py3.8-linux-x86_64.egg/cryptography/hazmat/primitives/serialization/base.py", line 9, in <module>
    from cryptography.hazmat.primitives.asymmetric.types import (
  File "/usr/local/lib/python3.8/site-packages/cryptography-36.0.0-py3.8-linux-x86_64.egg/cryptography/hazmat/primitives/asymmetric/types.py", line 7, in <module>
    from cryptography.hazmat.primitives.asymmetric import (
  File "/usr/local/lib/python3.8/site-packages/cryptography-36.0.0-py3.8-linux-x86_64.egg/cryptography/hazmat/primitives/asymmetric/dsa.py", line 10, in <module>
    from cryptography.hazmat.primitives.asymmetric import (
  File "/usr/local/lib/python3.8/site-packages/cryptography-36.0.0-py3.8-linux-x86_64.egg/cryptography/hazmat/primitives/asymmetric/utils.py", line 6, in <module>
    from cryptography.hazmat.bindings._rust import asn1
ImportError: Error loading shared library libgcc_s.so.1: No such file or directory (needed by /usr/local/lib/python3.8/site-packages/cryptography-36.0.0-py3.8-linux-x86_64.egg/cryptography/hazmat/bindings/_rust.abi3.so)
```

## How Has This Been Tested?
Built and ran Docker image successfully

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
