### PR TITLE
Fix Docker build and standalone make

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-alpine
+FROM python:3.11-alpine
 
 WORKDIR /opt/gimme-aws-creds
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 ifdef OS
 	SEP := ;
 else
-  	SEP := :
+	SEP := :
 endif
 
 docker-build:
@@ -20,4 +20,4 @@ init:	venv
 exe: init
 	./venv/bin/python3 -mpip install .
 	$(eval FIDODIR := $(shell ./venv/bin/python3 -c "import fido2;from os import path as op;print(op.dirname(fido2.__file__))"))
-	./venv/bin/python3 -mPyInstaller -F --paths=.. --hidden-import=gimme_aws_creds --add-data "$(FIDODIR)/public_suffix_list.dat$(SEP)fido2" bin/gimme-aws-creds
+	./venv/bin/python3 -mPyInstaller -F --hidden-import=gimme_aws_creds --add-data "$(FIDODIR)/public_suffix_list.dat$(SEP)fido2" bin/gimme-aws-creds

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
 ifdef OS
+	BIN    := Scripts
 	PYTHON := python
 	SEP := ;
 else
+	BIN    := bin
 	PYTHON := python3
 	SEP := :
 endif
@@ -16,10 +18,10 @@ venv:
 	$(PYTHON) -mvenv ./venv
 
 init:	venv
-	./venv/bin/$(PYTHON) -mpip install -r requirements_dev.txt
+	./venv/$(BIN)/$(PYTHON) -mpip install -r requirements_dev.txt
 
 
 exe: init
-	./venv/bin/$(PYTHON) -mpip install .
-	$(eval FIDODIR := $(shell ./venv/bin/python3 -c "import fido2;from os import path as op;print(op.dirname(fido2.__file__))"))
-	./venv/bin/$(PYTHON) -mPyInstaller -F --hidden-import=gimme_aws_creds --add-data "$(FIDODIR)/public_suffix_list.dat$(SEP)fido2" bin/gimme-aws-creds
+	./venv/$(BIN)/$(PYTHON) -mpip install .
+	$(eval FIDODIR := $(shell ./venv/$(BIN)/python3 -c "import fido2;from os import path as op;print(op.dirname(fido2.__file__))"))
+	./venv/$(BIN)/$(PYTHON) -mPyInstaller -F --hidden-import=gimme_aws_creds --add-data "$(FIDODIR)/public_suffix_list.dat$(SEP)fido2" bin/gimme-aws-creds

--- a/Makefile
+++ b/Makefile
@@ -4,16 +4,20 @@ else
   	SEP := :
 endif
 
-init:
-	python3 -mpip install -r requirements_dev.txt
-
 docker-build:
 	docker build -t gimme-aws-creds .
 
 test: docker-build
 	nosetests -vv tests
 
+venv:
+	python3 -mvenv ./venv
+
+init:	venv
+	./venv/bin/python3 -mpip install -r requirements_dev.txt
+
+
 exe: init
-	python3 -mpip install .
-	$(eval FIDODIR := $(shell python3 -c "import fido2;from os import path as op;print(op.dirname(fido2.__file__))"))
-	pyinstaller -F --hidden-import=gimme_aws_creds --add-data "$(FIDODIR)/public_suffix_list.dat$(SEP)fido2" bin/gimme-aws-creds
+	./venv/bin/python3 -mpip install .
+	$(eval FIDODIR := $(shell ./venv/bin/python3 -c "import fido2;from os import path as op;print(op.dirname(fido2.__file__))"))
+	./venv/bin/python3 -mPyInstaller -F --paths=.. --hidden-import=gimme_aws_creds --add-data "$(FIDODIR)/public_suffix_list.dat$(SEP)fido2" bin/gimme-aws-creds

--- a/Makefile
+++ b/Makefile
@@ -23,5 +23,5 @@ init:	venv
 
 exe: init
 	./venv/$(BIN)/$(PYTHON) -mpip install .
-	$(eval FIDODIR := $(shell ./venv/$(BIN)/python3 -c "import fido2;from os import path as op;print(op.dirname(fido2.__file__))"))
+	$(eval FIDODIR := $(shell ./venv/$(BIN)/$(PYTHON) -c "import fido2;from os import path as op;print(op.dirname(fido2.__file__))"))
 	./venv/$(BIN)/$(PYTHON) -mPyInstaller -F --hidden-import=gimme_aws_creds --add-data "$(FIDODIR)/public_suffix_list.dat$(SEP)fido2" bin/gimme-aws-creds

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ else
 endif
 
 init:
-	python -mpip install -r requirements_dev.txt
+	python3 -mpip install -r requirements_dev.txt
 
 docker-build:
 	docker build -t gimme-aws-creds .
@@ -14,6 +14,6 @@ test: docker-build
 	nosetests -vv tests
 
 exe: init
-	python -mpip install .
-	$(eval FIDODIR := $(shell python -c "import fido2;from os import path as op;print(op.dirname(fido2.__file__))"))
+	python3 -mpip install .
+	$(eval FIDODIR := $(shell python3 -c "import fido2;from os import path as op;print(op.dirname(fido2.__file__))"))
 	pyinstaller -F --hidden-import=gimme_aws_creds --add-data "$(FIDODIR)/public_suffix_list.dat$(SEP)fido2" bin/gimme-aws-creds

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 ifdef OS
+	PYTHON := python
 	SEP := ;
 else
+	PYTHON := python3
 	SEP := :
 endif
 
@@ -11,13 +13,13 @@ test: docker-build
 	nosetests -vv tests
 
 venv:
-	python3 -mvenv ./venv
+	$(PYTHON) -mvenv ./venv
 
 init:	venv
-	./venv/bin/python3 -mpip install -r requirements_dev.txt
+	./venv/bin/$(PYTHON) -mpip install -r requirements_dev.txt
 
 
 exe: init
-	./venv/bin/python3 -mpip install .
+	./venv/bin/$(PYTHON) -mpip install .
 	$(eval FIDODIR := $(shell ./venv/bin/python3 -c "import fido2;from os import path as op;print(op.dirname(fido2.__file__))"))
-	./venv/bin/python3 -mPyInstaller -F --hidden-import=gimme_aws_creds --add-data "$(FIDODIR)/public_suffix_list.dat$(SEP)fido2" bin/gimme-aws-creds
+	./venv/bin/$(PYTHON) -mPyInstaller -F --hidden-import=gimme_aws_creds --add-data "$(FIDODIR)/public_suffix_list.dat$(SEP)fido2" bin/gimme-aws-creds

--- a/gimme_aws_creds/__init__.py
+++ b/gimme_aws_creds/__init__.py
@@ -1,2 +1,2 @@
 __all__ = ['config', 'okta', 'main', 'ui']
-version = '2.5.0.1'
+version = '2.5.0.3'

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ requests>=2.13.0,<3.0.0
 fido2>=0.9.1,<0.10.0
 okta>=0.0.4,<1.0.0
 ctap-keyring-device>=1.0.6
+urllib3<2.0.0


### PR DESCRIPTION
Docker build was installing latest urllib3, which is incompatible with this codebase. Bumped the base image to the latest available, as well. Also, standalone executable generation was invoking `python`, which is not guaranteed to exist; `python3` is more portable.