### PR TITLE
fix: use newer Python

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-alpine
+FROM python:3.12-alpine
 
 WORKDIR /opt/gimme-aws-creds
 

--- a/gimme_aws_creds/__init__.py
+++ b/gimme_aws_creds/__init__.py
@@ -3,4 +3,4 @@ __all__ = [
   'okta_classic', 'okta_identity_engine', 'registered_authenticators', 'u2f',
   'webauthn'
 ]
-version = '2.7.2.1'
+version = '2.7.2.2'


### PR DESCRIPTION
Previous prebuilt binary seems to crash trying to access the macOS keychain on newer Macs. This code change just bumps the Python base image version in the Dockerfile; the real fix is rebuilding the binary on a newer version of macOS.