### PR TITLE
get automatic release workflow working

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -4,10 +4,7 @@ description: build standalone executables using PyInstaller
 on:
   push:
     branches: 
-      - '*'
-  pull_request:
-    branches: 
-      - '*'
+      - 'master'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
         id: get_run_id
         run: |
             run_id=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-                "https://api.github.com/repos/${OWNER}/${REPO_NAME}/actions/workflows/binaries.yml/runs?status=success" | \
+                "https://api.github.com/repos/${{ github.repository }}/actions/workflows/binaries.yml/runs?status=success" | \
             jq -r '.workflow_runs|sort_by(.updated_at)[-1].id')
             printf 'run_id=%s\n' "$run_id" >>"$GITHUB_OUTPUT"
       - name: Download all workflow run artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
         id: get_run_id
         run: |
             run_id=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-                "https://api.github.com/repos/${{ github.repository }}/actions/workflows/binaries.yml/runs?status=success" | \
+                "https://api.github.com/repos/${OWNER}/${REPO_NAME}/actions/workflows/binaries.yml/runs?status=success" | \
             jq -r '.workflow_runs|sort_by(.updated_at)[-1].id')
             printf 'run_id=%s\n' "$run_id" >>"$GITHUB_OUTPUT"
       - name: Download all workflow run artifacts
@@ -24,8 +24,11 @@ jobs:
           path: ./artifacts
           run-id: ${{ steps.get_run_id.outputs.run_id }}
       - name: Create Release
+        id: create_release
         uses: softprops/action-gh-release@v2
+      - name: Upload artifacts
+        uses: svenstaro/upload-release-action@v2
         with:
-          files: ./artifacts/**/*
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: artifacts/*
+          tag: ${{ github.ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,8 +18,8 @@ jobs:
                 "https://api.github.com/repos/${{ github.repository }}/actions/workflows/binaries.yml/runs?status=success&per_page=1" | \
             jq -r '.workflow_runs[0].id')
             if [ -z "$run_id" ] || [ "$run_id" = "null" ]; then
-              echo "No successful workflow runs found for binaries.yml. Cannot proceed with release." >&2
-              exit 1
+                printf >&2 'No successful workflow runs found for binaries.yml. Cannot create release.\n'
+                exit 1
             fi
             printf 'run_id=%s\n' "$run_id" >>"$GITHUB_OUTPUT"
       - name: Download all workflow run artifacts
@@ -30,14 +30,23 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Archive artifacts
         run: |
-            cd artifacts
+            cd artifacts || {
+              printf >&2 'No artifacts directory. Cannot create release.\n';
+              exit 1
+            }
+            found=0
             for dir in */; do
                if [ -n "$(ls -A "$dir" 2>/dev/null)" ]; then
                  (cd "$dir" && zip -r "../${dir%/}.zip" .)
+                 found=1
                else
                  echo "Skipping $dir: directory is empty"
                fi
             done
+            if [ $found -eq 0 ]; then
+                printf >&2 'No files to archive. Cannot create release.\n'
+                exit 1
+            fi
       - name: Create release and upload assets
         id: create_release
         uses: ncipollo/release-action@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
         id: get_run_id
         run: |
             run_id=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-                "https://api.github.com/repos/${{ github.repository }}/actions/workflows/binaries.yml/runs?status=success" | \
+                "https://api.github.com/repos/${{ github.repository }}/actions/workflows/binaries.yml/runs?status=success&per_page=1" | \
             jq -r '.workflow_runs|sort_by(.updated_at)[-1].id')
             printf 'run_id=%s\n' "$run_id" >>"$GITHUB_OUTPUT"
       - name: Download all workflow run artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
         run: |
             cd artifacts
             for dir in */; do
-               if [ -n "$(find "$dir" -mindepth 1 -print -quit)" ]; then
+               if [ -n "$(ls -A "$dir" 2>/dev/null)" ]; then
                  (cd "$dir" && zip -r "../${dir%/}.zip" .)
                else
                  echo "Skipping $dir: directory is empty"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,10 +24,16 @@ jobs:
           path: ./artifacts
           run-id: ${{ steps.get_run_id.outputs.run_id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Archive artifacts
+        run: |
+            cd artifacts
+            for dir in */; do
+               (cd "$dir" && zip "../${dir%/}.zip" *)
+            done
       - name: Create release and upload assets
         id: create_release
         uses: ncipollo/release-action@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          artifacts: "artifacts/*/*"
+          artifacts: "artifacts/*.zip"
           tag: ${{ github.ref_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
         run: |
             run_id=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
                 "https://api.github.com/repos/${{ github.repository }}/actions/workflows/binaries.yml/runs?status=success&per_page=1" | \
-            jq -r '.workflow_runs|sort_by(.updated_at)[-1].id')
+            jq -r '.workflow_runs[0].id')
             printf 'run_id=%s\n' "$run_id" >>"$GITHUB_OUTPUT"
       - name: Download all workflow run artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,7 @@ jobs:
         with:
           path: ./artifacts
           run-id: ${{ steps.get_run_id.outputs.run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Create Release
         id: create_release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,12 +24,10 @@ jobs:
           path: ./artifacts
           run-id: ${{ steps.get_run_id.outputs.run_id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Create Release
+      - name: Create release and upload assets
         id: create_release
-        uses: softprops/action-gh-release@v2
-      - name: Upload artifacts
-        uses: svenstaro/upload-release-action@v2
+        uses: ncipollo/release-action@v1
         with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: artifacts/*
-          tag: ${{ github.ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          artifacts: "artifacts/*.zip"
+          tag: ${{ github.ref_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
             cd artifacts
             for dir in */; do
-               (cd "$dir" && zip "../${dir%/}.zip" *)
+               (cd "$dir" && zip -r "../${dir%/}.zip" . 2>/dev/null || true)
             done
       - name: Create release and upload assets
         id: create_release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
             found=0
             for dir in */; do
                if [ -n "$(ls -A "$dir" 2>/dev/null)" ]; then
-                 (cd "$dir" && zip -r "../${dir%/}.zip" .)
+                 (cd "$dir" && zip -r "../${dir%/}.zip" .) || { echo "Failed to create zip for $dir"; exit 1; }
                  found=1
                else
                  echo "Skipping $dir: directory is empty"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,5 +29,5 @@ jobs:
         uses: ncipollo/release-action@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          artifacts: "artifacts/*.zip"
+          artifacts: "artifacts/*"
           tag: ${{ github.ref_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,5 +29,5 @@ jobs:
         uses: ncipollo/release-action@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          artifacts: "artifacts/*"
+          artifacts: "artifacts/*/*"
           tag: ${{ github.ref_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,10 @@ jobs:
             run_id=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
                 "https://api.github.com/repos/${{ github.repository }}/actions/workflows/binaries.yml/runs?status=success&per_page=1" | \
             jq -r '.workflow_runs[0].id')
+            if [ -z "$run_id" ] || [ "$run_id" = "null" ]; then
+              echo "No successful workflow runs found for binaries.yml. Cannot proceed with release." >&2
+              exit 1
+            fi
             printf 'run_id=%s\n' "$run_id" >>"$GITHUB_OUTPUT"
       - name: Download all workflow run artifacts
         uses: actions/download-artifact@v4
@@ -28,7 +32,11 @@ jobs:
         run: |
             cd artifacts
             for dir in */; do
-               (cd "$dir" && zip -r "../${dir%/}.zip" . 2>/dev/null || true)
+               if [ -n "$(find "$dir" -mindepth 1 -print -quit)" ]; then
+                 (cd "$dir" && zip -r "../${dir%/}.zip" .)
+               else
+                 echo "Skipping $dir: directory is empty"
+               fi
             done
       - name: Create release and upload assets
         id: create_release


### PR DESCRIPTION
original version only works if the artifacts were uploaded by the same workflow run; current version doesn't work at all due to a mistake in deriving the repository slug.