### PR TITLE
TypeError in _get_cred_profile profiles.Profile() is called with a missing include_path argument 

### DIFF
--- a/gimme_aws_creds/config.py
+++ b/gimme_aws_creds/config.py
@@ -521,7 +521,7 @@ class Config(object):
         cred_profile = self._get_user_input(
             "AWS Credential Profile", default_entry)
 
-        cred_profile = profiles.Profile(cred_profile).canonicalize()
+        cred_profile = profiles.Profile(cred_profile, False).canonicalize()
         return cred_profile
 
     def _get_aws_appname(self, default_entry):


### PR DESCRIPTION

## Description
Running `gimmie-aws-creds --action-configure` raises a `TypeError` when the user answers `y` to `"Write AWS Credentials"`

`TypeError: Profile.__init__() missing one required positional argument: 'include_path'`
Raised at `gimmie_aws_creds/config.py line 524`

Profile.__init__() in profiles.py requires two arguments:

`def __init__(self, cred_profile, include_path)`

but the call in _get_credit_profile() only passes one:

`cred_profile = profiles.Profile(cred_profile).canonicalize()`

Very minor fix to provide a safe default: 

`cred_profile = profiles.Profile(cred_profile, False).canonicalize()`

False is a safe default here, as canonicalize() does not use include_path


## Related Issue
Issue raised as https://github.com/WarnerMedia/gimme-aws-creds/issues/32


## Motivation and Context
Downloaded the latest release and got a `TypeError` when trying to run the exe for the first time

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

ran existing tests,  and then ran `gimmie-aws-creds --action-configure` to verify fix works

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
